### PR TITLE
Login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,36 @@ geckodriver.log
 # HTML
 *.html
 
+# VSCode
 .vscode
+*.code-workspace
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+twill
+schedule

--- a/twillmain.py
+++ b/twillmain.py
@@ -54,7 +54,6 @@ def tomar_ramos(NRC):  # Esto debe ser de una corrida ya que usa Sessions
     submit('0')
     avance = 80
 
-    save_html('pruebadetoma.html')
     # Aplicar NRC
     if len(NRC) == 1:
         fv('2', 'crn_id1', NRC[0])
@@ -94,9 +93,10 @@ def verificar_sesion(usuario, password) -> tuple:
     print('\nChequeando credenciales...')
     redirect_output('output.log')
     go('https://ssb.uc.cl/ERPUC/twbkwbis.P_WWWLogin')
-    formclear('1')
-    fv('1', 'sid', usuario)
-    fv('1', 'PIN', password)
+    formnum = f'{len(showforms())}'
+    formclear(formnum)
+    fv(formnum, 'sid', usuario)
+    fv(formnum, 'PIN', password)
     submit('0')
     go("http://ssb.uc.cl/ERPUC/twbkwbis.P_GenMenu?name=bmenu.P_MainMnu")
     reset_output()

--- a/twillmain.py
+++ b/twillmain.py
@@ -111,13 +111,14 @@ def verificar_sesion(usuario, password) -> tuple:
 
 def necesitaRelogin(hora):
     '''
-    Retorna True si "hora" ocurrirá en más de 15 minutos, False en caso contrario.
+    Retorna True si "hora" ocurrirá en más de 10 minutos, False en caso contrario.
         hora: Un string con la forma "%H:%M"
     '''
     actual = dt.now()
     reserva = dt.combine(actual, time.fromisoformat(hora))
     waittime = (reserva - actual).total_seconds()
-    if waittime >= 15*60 or waittime < 0:
+    minutos_espera = 10
+    if waittime >= minutos_espera*60 or waittime < 0:
         return True
     return False
 

--- a/twillmain.py
+++ b/twillmain.py
@@ -1,4 +1,5 @@
 from twill.commands import *
+from getpass import getpass
 import schedule
 from functions import obtener_errores_de
 
@@ -10,7 +11,7 @@ def main():
     print('Creador con <3 por Dyotson (Max Militzer) y voluntarios de OSUC\n')
     print("¡NO CIERRES EL PROGRAMA HASTA QUE ESTE TOME RAMOS Y TE CONFIRME!\n")
     usuario = input("Usuario UC: ")
-    password = input("Contraseña UC: ")
+    password = getpass("Contraseña UC: ")
     chequeo = verificar_sesion(usuario, password)
     if chequeo[0] is False:
         exit()
@@ -76,7 +77,8 @@ def tomar_ramos(usuario, password, NRC):  # Esto debe ser de una corrida ya que 
 
 def reservar(usuario, password, NRC, hora):
     try:
-        schedule.every().day.at(hora).do(tomar_ramos, usuario=usuario, password=password, NRC=NRC)
+        schedule.every().day.at(hora).do(
+            tomar_ramos, usuario=usuario, password=password, NRC=NRC)
         while True:
             schedule.run_pending()
     except:


### PR DESCRIPTION
Este PR se enfoca en diferentes aspectos relacionados al inicio de sesión del usuario en banner. En particular, se soluciona el problema expuesto en la issue #12.

### Aportes principales:
- Por seguridad, cuando el usuario ingresa su contraseña esta ya no se muestra en pantalla.
- Se asegura de que, al momento de tomar ramos, haya ocurrido un inicio de sesión a lo más hace 10 minutos.

 ### Aportes secundarios:
 - Se adjunta un archivo `requirements.txt` para instalar todas las librerías necesarias con un solo comando.
 - Se ignoran algunos archivos comunes de macOS.

### Explicación solución a issue #12

El problema ocurría porque el programa solo iniciaba sesión previo a reservar la hora de toma de ramos. Sin embargo las sesiones de Banner solo son válidas por 15 minutos, por lo que si se  realizada una reserva con más de 15 minutos de anticipación, al intentar tomar ramos saltaba un error porque la sesión ya no era válida.

Una posible solución habría sido iniciar sesión siempre al inicio de `tomar_ramos`, pero tenía 2 inconvenientes:
1. Retrasaría un poco el acto mismo de tomar ramos, lo cual puede ser crucial para algunes usuaries.
2. Cuando se intentaba iniciar sesión con una sesión ya activa, el HTML no era exáctamente igual, por lo que saltaba un error.

Para solucionar el **primer inconveniente** establecí un segundo _schedule_ que se ejecuta 5 minutos previo al original y se encarga de realizar un inicio de sesión. Esto solo ocurre en los casos en que la reserva se realiza con más de 10 minutos de anticipación¹. El código más importante relacionado con esta solución puede encontrarse al inicio de la función `reservar`.

Para solucionar el **segundo inconveniente**, fue necesario notar que el único cambio en el HTML cuando la sesión ya estaba iniciada era que se agregaba un formulario adicional antes del formulario de inicio de sesión. Como la función `verificar_sesion` siempre intentaba rellenar los campos del primer formulario disponible, se producía un error al apuntar al formulario equivocado. Por lo tanto, solo fue necesario que la función `verificar_sesion` revise siempre el último formulario de la lista en `showforms()`, el cual en todos los casos es el formulario correcto.

**_TL;DR:_** Con todo esto resuelto, esta PR permite repetir el inicio de sesión 5 minutos antes de la toma de ramos (en los casos donde sea necesario). Así, la toma de ramos sigue siendo instantánea y siempre redirigirá al menu de banner con la sesión ya iniciada.


> ¹ Las sesiones de banner duran 15 minutos, pero se prefirió renovar la sesión a los 10 minutos para dejar un margen de error ante posibles cambios.